### PR TITLE
Making sure exceptions during validation always include a mention of the file in question

### DIFF
--- a/openapi_to_fastapi/routes.py
+++ b/openapi_to_fastapi/routes.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter
 from .model_generator import load_models
 from .parser import parse_openapi_spec
 from .utils import add_annotation_to_first_argument, copy_function
-from .validator.core import BaseValidator, DefaultValidator
+from .validator.core import BaseValidator, DefaultValidator, ValidationError
 
 
 def dummy_route(request):
@@ -75,8 +75,11 @@ class SpecRouter:
             specs = self.specs_path.glob("**/*.json")
 
         for spec_path in specs:
-            for validator in self._validators:
-                validator(spec_path).validate()
+            try:
+                for validator in self._validators:
+                    validator(spec_path).validate()
+            except Exception as e:
+                raise ValidationError(f"Failed to validate {spec_path}: {e}")
 
             raw_spec = spec_path.read_text()
             json_spec = json.loads(raw_spec)

--- a/openapi_to_fastapi/routes.py
+++ b/openapi_to_fastapi/routes.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter
 from .model_generator import load_models
 from .parser import parse_openapi_spec
 from .utils import add_annotation_to_first_argument, copy_function
-from .validator.core import BaseValidator, DefaultValidator, ValidationError
+from .validator.core import BaseValidator, DefaultValidator
 
 
 def dummy_route(request):

--- a/openapi_to_fastapi/routes.py
+++ b/openapi_to_fastapi/routes.py
@@ -75,11 +75,8 @@ class SpecRouter:
             specs = self.specs_path.glob("**/*.json")
 
         for spec_path in specs:
-            try:
-                for validator in self._validators:
-                    validator(spec_path).validate()
-            except Exception as e:
-                raise ValidationError(f"Failed to validate {spec_path}: {e}")
+            for validator in self._validators:
+                validator(spec_path).validate()
 
             raw_spec = spec_path.read_text()
             json_spec = json.loads(raw_spec)

--- a/openapi_to_fastapi/validator/core.py
+++ b/openapi_to_fastapi/validator/core.py
@@ -4,7 +4,11 @@ from pathlib import Path
 from typing import Union
 
 
-class OpenApiValidationError(Exception):
+class ValidationError(Exception):
+    pass
+
+
+class OpenApiValidationError(ValidationError):
     pass
 
 

--- a/openapi_to_fastapi/validator/core.py
+++ b/openapi_to_fastapi/validator/core.py
@@ -33,6 +33,8 @@ class BaseValidator:
             spec = json.loads(self.path.read_text())
         except json.JSONDecodeError:
             raise InvalidJSON(f"Incorrect JSON: {self.path}")
+        except Exception as e:
+            raise ValidationError(f"Failed to validate {self.path}: {e}")
         self.validate_spec(spec)
 
     @abc.abstractmethod


### PR DESCRIPTION
I ended up with an exception when testing something locally:

```
app\routers\dataproduct.py:108: in make_data_products_router
    spec_router = SpecRouter(data_products_path, validators=[IhanStandardsValidator])
C:\Users\lietu\AppData\Local\pypoetry\Cache\virtualenvs\productgateway-v1beta-7SaAo4-b-py3.9\lib\site-packages\openapi_to_fastapi\routes.py:66: in __init__
    self._validate_and_parse_specs()
C:\Users\lietu\AppData\Local\pypoetry\Cache\virtualenvs\productgateway-v1beta-7SaAo4-b-py3.9\lib\site-packages\openapi_to_fastapi\routes.py:79: in _validate_and_parse_specs
    validator(spec_path).validate()
C:\Users\lietu\AppData\Local\pypoetry\Cache\virtualenvs\productgateway-v1beta-7SaAo4-b-py3.9\lib\site-packages\openapi_to_fastapi\validator\core.py:29: in validate
    spec = json.loads(self.path.read_text())
c:\python39\lib\pathlib.py:1256: in read_text
    return f.read()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <encodings.cp1252.IncrementalDecoder object at 0x00000226193082E0>
input = b'{\n  "openapi": "3.0.2",\n  "info": {\n    "title": "Air Quality Index",\n    "description": "Data Product for curre... {\n            "title": "Error Type",\n            "type": "string"\n          }\n        }\n      }\n    }\n  }\n}\n'
final = True

    def decode(self, input, final=False):
>       return codecs.charmap_decode(input,self.errors,decoding_table)[0]
E       UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 4748: character maps to <undefined>
```

The `UnicodeDecodeError` is not caught by the `BaseValidator` and so no filename is included in it, which makes debugging quite a bit more difficult.