### PR TITLE
Fix usage of `NamedTemporaryFile` for `import` in Windows.

### DIFF
--- a/openapi_to_fastapi/model_generator.py
+++ b/openapi_to_fastapi/model_generator.py
@@ -4,7 +4,6 @@ import uuid
 from contextlib import contextmanager
 from pathlib import Path
 from tempfile import _TemporaryFileWrapper
-from typing import IO
 
 from datamodel_code_generator import (
     BaseModel,

--- a/openapi_to_fastapi/model_generator.py
+++ b/openapi_to_fastapi/model_generator.py
@@ -1,7 +1,7 @@
 import importlib.util
 import tempfile
 import uuid
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from pathlib import Path
 from tempfile import _TemporaryFileWrapper
 
@@ -52,7 +52,8 @@ def _clean_tempfile(tmp_file: _TemporaryFileWrapper, delete=True):
     finally:
         if delete:
             tmp_file.close()
-            Path(tmp_file.name).unlink(missing_ok=True)
+            with suppress(FileNotFoundError):
+                Path(tmp_file.name).unlink()
 
 
 def load_models(schema: str, name: str = "", cleanup: bool = True):

--- a/openapi_to_fastapi/model_generator.py
+++ b/openapi_to_fastapi/model_generator.py
@@ -1,6 +1,10 @@
 import importlib.util
 import tempfile
 import uuid
+from contextlib import contextmanager
+from pathlib import Path
+from tempfile import _TemporaryFileWrapper
+from typing import IO
 
 from datamodel_code_generator import (
     BaseModel,
@@ -42,6 +46,16 @@ def generate_model_from_schema(schema: str) -> str:
     return str(result)
 
 
+@contextmanager
+def _clean_tempfile(tmp_file: _TemporaryFileWrapper, delete=True):
+    try:
+        yield tmp_file
+    finally:
+        if delete:
+            tmp_file.close()
+            Path(tmp_file.name).unlink(missing_ok=True)
+
+
 def load_models(schema: str, name: str = "", cleanup: bool = True):
     """
     Generate pydantic models from OpenAPI spec and return a python module,
@@ -54,9 +68,9 @@ def load_models(schema: str, name: str = "", cleanup: bool = True):
     :return: Module with pydantic models
     """
     prefix = name.replace("/", "").replace(" ", "").replace("\\", "") + "_"
-    with tempfile.NamedTemporaryFile(
-        prefix=prefix, mode="w", suffix=".py", delete=cleanup
-    ) as tmp_file:
+    with _clean_tempfile(tempfile.NamedTemporaryFile(
+        prefix=prefix, mode="w", suffix=".py", delete=False
+    ), delete=cleanup) as tmp_file:
         model_py = generate_model_from_schema(schema)
         tmp_file.write(model_py)
         if not cleanup:

--- a/openapi_to_fastapi/model_generator.py
+++ b/openapi_to_fastapi/model_generator.py
@@ -67,9 +67,12 @@ def load_models(schema: str, name: str = "", cleanup: bool = True):
     :return: Module with pydantic models
     """
     prefix = name.replace("/", "").replace(" ", "").replace("\\", "") + "_"
-    with _clean_tempfile(tempfile.NamedTemporaryFile(
-        prefix=prefix, mode="w", suffix=".py", encoding="utf8", delete=False
-    ), delete=cleanup) as tmp_file:
+    with _clean_tempfile(
+        tempfile.NamedTemporaryFile(
+            prefix=prefix, mode="w", suffix=".py", encoding="utf8", delete=False
+        ),
+        delete=cleanup,
+    ) as tmp_file:
         model_py = generate_model_from_schema(schema)
         tmp_file.write(model_py)
         if not cleanup:

--- a/openapi_to_fastapi/model_generator.py
+++ b/openapi_to_fastapi/model_generator.py
@@ -3,7 +3,6 @@ import tempfile
 import uuid
 from contextlib import contextmanager, suppress
 from pathlib import Path
-from tempfile import _TemporaryFileWrapper
 
 from datamodel_code_generator import (
     BaseModel,

--- a/openapi_to_fastapi/model_generator.py
+++ b/openapi_to_fastapi/model_generator.py
@@ -46,7 +46,7 @@ def generate_model_from_schema(schema: str) -> str:
 
 
 @contextmanager
-def _clean_tempfile(tmp_file: _TemporaryFileWrapper, delete=True):
+def _clean_tempfile(tmp_file, delete=True):
     try:
         yield tmp_file
     finally:

--- a/openapi_to_fastapi/model_generator.py
+++ b/openapi_to_fastapi/model_generator.py
@@ -69,7 +69,7 @@ def load_models(schema: str, name: str = "", cleanup: bool = True):
     """
     prefix = name.replace("/", "").replace(" ", "").replace("\\", "") + "_"
     with _clean_tempfile(tempfile.NamedTemporaryFile(
-        prefix=prefix, mode="w", suffix=".py", delete=False
+        prefix=prefix, mode="w", suffix=".py", encoding="utf8", delete=False
     ), delete=cleanup) as tmp_file:
         model_py = generate_model_from_schema(schema)
         tmp_file.write(model_py)

--- a/openapi_to_fastapi/routes.py
+++ b/openapi_to_fastapi/routes.py
@@ -78,7 +78,7 @@ class SpecRouter:
             for validator in self._validators:
                 validator(spec_path).validate()
 
-            raw_spec = spec_path.read_text()
+            raw_spec = spec_path.read_text(encoding="utf8")
             json_spec = json.loads(raw_spec)
             for path, path_item in parse_openapi_spec(json_spec).items():
                 models = load_models(raw_spec, path)

--- a/openapi_to_fastapi/tests/test_ihan_standards.py
+++ b/openapi_to_fastapi/tests/test_ihan_standards.py
@@ -13,7 +13,7 @@ from ..validator import ihan_standards as ihan
 
 SPECS_ROOT_DIR = Path(__file__).absolute().parent / "data"
 COMPANY_BASIC_INFO: dict = json.loads(
-    (SPECS_ROOT_DIR / "ihan" / "CompanyBasicInfo.json").read_text()
+    (SPECS_ROOT_DIR / "ihan" / "CompanyBasicInfo.json").read_text(encoding="utf8")
 )
 
 

--- a/openapi_to_fastapi/tests/test_router.py
+++ b/openapi_to_fastapi/tests/test_router.py
@@ -26,7 +26,7 @@ def test_routes_are_created(ihan_client, specs_root):
 
 def test_pydantic_model_loading(specs_root):
     path = specs_root / "ihan" / "CompanyBasicInfo.json"
-    spec = json.loads(path.read_text())
+    spec = json.loads(path.read_text(encoding="utf8"))
     module = load_models(spec, "/Company/BasicInfo")
     assert module.BasicCompanyInfoRequest
     assert module.BasicCompanyInfoResponse

--- a/openapi_to_fastapi/validator/core.py
+++ b/openapi_to_fastapi/validator/core.py
@@ -26,7 +26,7 @@ class BaseValidator:
 
     def validate(self):
         try:
-            spec = json.loads(self.path.read_text())
+            spec = json.loads(self.path.read_text(encoding="utf8"))
         except json.JSONDecodeError:
             raise InvalidJSON(f"Incorrect JSON: {self.path}")
         self.validate_spec(spec)


### PR DESCRIPTION
`NamedTemporaryFile` detects Windows and uses built-in OS features for marking the file as a temporary file when `delete=True`. Windows then disallows opening the file again (by import) until it is `close()`d and automatically deletes it on `close()`.

This means that to support Windows we have to have our own cleanup logic.