### PR TITLE
Updated pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.0.1
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -14,20 +14,20 @@ repos:
       - id: seed-isort-config
         args: [--application-directories=openapi_to_fastapi]
   - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.5.1
+    rev: v5.9.2
     hooks:
       - id: isort
-        language_version: python3.8
+        language_version: python3
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.7b0
     hooks:
       - id: black
-        language_version: python3.8
-  - repo: https://github.com/prettier/prettier
-    rev: 2.1.1
+        language_version: python3
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.3.2
     hooks:
       - id: prettier
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.3
+    rev: 3.9.2
     hooks:
       - id: flake8


### PR DESCRIPTION
 - Used `pre-commit autoupdate` to get most of these.
 - Switched `python3.8` to `python3` as it should be as good for most people and works for people who no longer have 3.8 installed like me 🙂
 - `Prettier support for pre-commit has been moved to https://github.com/pre-commit/mirrors-prettier, please use the new repository.`